### PR TITLE
Fixes psalm errors.

### DIFF
--- a/src/Models/Refund.php
+++ b/src/Models/Refund.php
@@ -1,6 +1,7 @@
 <?php namespace Tipoff\Refunds\Models;
 
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Stripe\Stripe;
 use Tipoff\Refunds\Notifications\RefundConfirmation;
@@ -57,7 +58,7 @@ class Refund extends BaseModel
     /**
      * Issue refund.
      *
-     * @return self
+     * @return self|null
      * @throws \Exception
      */
     public function issue()
@@ -66,11 +67,8 @@ class Refund extends BaseModel
             case Refund::METHOD_STRIPE:
                 return $this->stripeRefund();
 
-                break;
             case Refund::METHOD_VOUCHER:
                 return $this->voucherRefund();
-
-                break;
         }
     }
 
@@ -123,7 +121,10 @@ class Refund extends BaseModel
     {
         $amount = $this->amount;
 
-        $voucher = app('voucher')::create([
+        /** @var Model $voucherModel */
+        $voucherModel = app('voucher');
+
+        $voucher = $voucherModel::create([
             'location_id' => $this->payment->order->location_id,
             'customer_id' => $this->payment->customer_id,
             'voucher_type_id' => Refund::REFUND_VOUCHER_TYPE_ID,

--- a/src/Notifications/RefundConfirmation.php
+++ b/src/Notifications/RefundConfirmation.php
@@ -20,7 +20,7 @@ class RefundConfirmation extends Notification
     /**
      * Create a new notification instance.
      *
-     * @param Refund
+     * @param Refund $refund
      */
     public function __construct(Refund $refund)
     {
@@ -58,7 +58,7 @@ class RefundConfirmation extends Notification
         }
 
         if ($refund->isVoucher()) {
-            $message->line("Refund voucher code: " . $this->voucher->code);
+            $message->line("Refund voucher code: " . $this->refund->voucher->code);
         }
 
         return $message;


### PR DESCRIPTION
Fixes

```
ERROR: InvalidNullableReturnType - src/Models/Refund.php:60:16 - The declared return type 'Tipoff\Refunds\Models\Refund' for Tipoff\Refunds\Models\Refund::issue is not nullable, but 'Tipoff\Refunds\Models\Refund|null' contains null (see https://psalm.dev/144)
     * @return self


ERROR: UnevaluatedCode - src/Models/Refund.php:69:17 - Expressions after return/throw/continue (see https://psalm.dev/084)
                break;


ERROR: UnevaluatedCode - src/Models/Refund.php:73:17 - Expressions after return/throw/continue (see https://psalm.dev/084)
                break;


ERROR: UndefinedMethod - src/Models/Refund.php:126:20 - Method Illuminate\Contracts\Foundation\Application::create does not exist (see https://psalm.dev/022)
        $voucher = app('voucher')::create([
            'location_id' => $this->payment->order->location_id,
            'customer_id' => $this->payment->customer_id,
            'voucher_type_id' => Refund::REFUND_VOUCHER_TYPE_ID,
            'redeemable_at' => now(),
            'amount' => $amount,
            'creator_id' => $this->creator_id,
            'updater_id' => $this->updater_id,
        ]);


ERROR: InvalidDocblock - src/Notifications/RefundConfirmation.php:25:5 - Badly-formatted @param in docblock for Tipoff\Refunds\Notifications\RefundConfirmation::__construct (see https://psalm.dev/008)
    /**
     * Create a new notification instance.
     *
     * @param Refund
     */
    public function __construct(Refund $refund)


ERROR: UndefinedThisPropertyFetch - src/Notifications/RefundConfirmation.php:61:54 - Instance property Tipoff\Refunds\Notifications\RefundConfirmation::$voucher is not defined (see https://psalm.dev/041)
            $message->line("Refund voucher code: " . $this->voucher->code);
```