### PR TITLE
Add composer dependency on voucher to allow installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     "require": {
         "php": "^7.4|^8.0",
         "stripe/stripe-php": "^7.69",
-        "tipoff/authorization": "^2.3.2",
-        "tipoff/support": "^1.5.9",
-        "tipoff/vouchers": "^2.1"
+        "tipoff/authorization": "^2.5.0",
+        "tipoff/support": "^1.5.10",
+        "tipoff/vouchers": "^2.2.0"
     },
     "require-dev": {
         "tipoff/test-support": "^1.2.0"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "stripe/stripe-php": "^7.69",
-        "tipoff/authorization": "^2.3.0",
+        "tipoff/authorization": "^2.3.2",
         "tipoff/support": "^1.5.9",
         "tipoff/vouchers": "^2.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,11 @@
         "php": "^7.4|^8.0",
         "stripe/stripe-php": "^7.69",
         "tipoff/authorization": "^2.3.0",
-        "tipoff/support": "^1.5.5"
+        "tipoff/support": "^1.5.9",
+        "tipoff/vouchers": "^2.1"
     },
     "require-dev": {
-        "tipoff/test-support": "^1.1.2"
+        "tipoff/test-support": "^1.2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The dependency on voucher should be removable down the road, but its necessary now based on the current FK dependency in the migration.